### PR TITLE
Be more tolerant with jsx dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,1 @@
-{deps, [{jsx, "2.3.0", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.3.0"}}}]}.
+{deps, [{jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.3.0"}}}]}.


### PR DESCRIPTION
It seems like `jsxn` works just fine with the latest `jsx` release. Other libraries might depend upon different versions of `jsx`, which this merge facilitates.