### PR TITLE
Switching jsx dependency to 'master' branch.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,1 @@
-{deps, [{jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.3.0"}}}]}.
+{deps, [{jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}}]}.


### PR DESCRIPTION
jsx does releases in the master branch. Adjusting the dependency in this
way will automatically make jsxn use the latest version.

This at the same time fixes a bug that jsx doesn't work properly with rebar3:
the `return_maps` option doesn't work, as described in talentdeficit/jsx#70
